### PR TITLE
Update libalac dep to node 4 compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "minimist": "^1.2.0",
     "xtend": "^4.0.0",
-    "libalac": "^0.1.0",
+    "libalac": "git://github.com/microadam/node-libalac#497171fb1c0799cad10c224b1829b379a4815639",
     "readable-stream": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This makes alac2pcm compatible with node 0.10, 0.12 and 4.1

Have linked it directly to my version of libalac as I don't think my PR will be merged anytime soon, as the project seems mostly abandoned, plus it isn't complete (encoding doesn't work). Decoding works fine though, which is all this project requires.
